### PR TITLE
Specify checkout and setup-node versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
     # The steps for the job, executed in sequence
     steps:	
       # A GitHub action for checking out the current branch
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
 
       # A GitHub action to setup Node.js
-      - uses: actions/setup-node@master
+      - uses: actions/setup-node@v1
         with:
           node-version: "12"
 


### PR DESCRIPTION
Fixes a recent issue where GitHub Actions will pause indefinitely, due to the actions edited herein changing their default branch from 'master' to 'main'. Version specificity ensures nothing else needs to change